### PR TITLE
Fix failed to load kernel from CDROM

### DIFF
--- a/include/grub/disk.h
+++ b/include/grub/disk.h
@@ -166,7 +166,7 @@ typedef struct grub_disk_memberlist *grub_disk_memberlist_t;
 /* The size of a disk cache in 512B units. Must be at least as big as the
    largest supported sector size, currently 16K.  */
 #ifdef GRUB_MACHINE_EFI
-#define GRUB_DISK_CACHE_BITS	11
+#define GRUB_DISK_CACHE_BITS	10
 #else
 #define GRUB_DISK_CACHE_BITS	6
 #endif


### PR DESCRIPTION
b0110aee31409453d07a4d898c2ee387c19ff2c6 lead to load kernel failed,
change GRUB_DISK_CACHE_BITS to 10 can fix this issue.

Signed-off-by: chenzhihui chenzhihui4@huawei.com
